### PR TITLE
Stop multiple sickbeard instances

### DIFF
--- a/script.service.audo/resources/audo.py
+++ b/script.service.audo/resources/audo.py
@@ -58,7 +58,7 @@ pSabNzbdScripts = xbmc.translatePath(__addonhome__ + 'scripts')
 sabnzbd               = ['python', xbmc.translatePath(__programs__ + '/resources/SABnzbd/SABnzbd.py'),
                          '-d', '-f', pSabNzbdSettings, '-l 0']
 sickBeard             = ['python', xbmc.translatePath(__programs__ + '/resources/SickBeard/SickBeard.py'),
-                         '--daemon', '--datadir', __addonhome__, '--config', pSickBeardSettings]
+                         '--daemon', '--datadir', __addonhome__,'--pidfile=/run/sickbeard.pid', '--config', pSickBeardSettings]
 couchPotatoServer     = ['python', xbmc.translatePath(__programs__ + '/resources/CouchPotatoServer/CouchPotato.py'),
                          '--daemon', '--pid_file', xbmc.translatePath(__addonhome__ + 'couchpotato.pid'),
                          '--config_file', pCouchPotatoServerSettings]


### PR DESCRIPTION
Audo.py gets re-run when xbmc crashes and spawns multiple sickBeards.
